### PR TITLE
add file and fix env attributeerror

### DIFF
--- a/xuance/environment/gym/gym_vec_env.py
+++ b/xuance/environment/gym/gym_vec_env.py
@@ -169,7 +169,10 @@ class DummyVecEnv_Gym(VecEnv):
         self.buf_rews = np.zeros((self.num_envs,), dtype=np.float32)
         self.buf_infos = [{} for _ in range(self.num_envs)]
         self.actions = None
-        self.max_episode_length = env.max_episode_steps
+        try:
+            self.max_episode_length = env.max_episode_steps
+        except AttributeError:
+            self.max_episode_length=1000
 
     def reset(self):
         for e in range(self.num_envs):


### PR DESCRIPTION
When I try to run the example train code, I find there is no module "xuance.environment.new_env.new_vec_env". Therefore, I add the "__init__.py" in the "xuance\environment\new_env". Then, I run it again, it shows me the AttributeError: the env doesn't have max_episode_steps so I add this Exception Capture which make it run successfully.