### PR TITLE
fix: test results miscalculation in marl settings

### DIFF
--- a/xuance/torch/agents/core/off_policy_marl.py
+++ b/xuance/torch/agents/core/off_policy_marl.py
@@ -306,7 +306,7 @@ class OffPolicyMARLAgents(MARLAgents):
         envs = self.envs if env_fn is None else env_fn()
         num_envs = envs.num_envs
         videos, episode_videos = [[] for _ in range(num_envs)], []
-        episode_count, scores, best_score = 0, [0.0 for _ in range(num_envs)], -np.inf
+        episode_count, scores, best_score = 0, [], -np.inf
         obs_dict, info = envs.reset()
         state = envs.buf_state.copy() if self.use_global_state else None
         avail_actions = envs.buf_avail_actions if self.use_actions_mask else None

--- a/xuance/torch/agents/core/on_policy_marl.py
+++ b/xuance/torch/agents/core/on_policy_marl.py
@@ -1,10 +1,18 @@
-from tqdm import tqdm
-import torch
-import numpy as np
-from copy import deepcopy
 from argparse import Namespace
+from copy import deepcopy
 from operator import itemgetter
-from xuance.common import MARL_OnPolicyBuffer, MARL_OnPolicyBuffer_RNN, Optional, List, Union
+
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from xuance.common import (
+    List,
+    MARL_OnPolicyBuffer,
+    MARL_OnPolicyBuffer_RNN,
+    Optional,
+    Union,
+)
 from xuance.environment import DummyVecMultiAgentEnv, SubprocVecMultiAgentEnv
 from xuance.torch import Module
 from xuance.torch.agents.base import MARLAgents
@@ -366,7 +374,7 @@ class OnPolicyMARLAgents(MARLAgents):
         envs = self.envs if env_fn is None else env_fn()
         num_envs = envs.num_envs
         videos, episode_videos = [[] for _ in range(num_envs)], []
-        episode_count, scores, best_score = 0, [0.0 for _ in range(num_envs)], -np.inf
+        episode_count, scores, best_score = 0, [], -np.inf
         obs_dict, info = envs.reset()
         avail_actions = envs.buf_avail_actions if self.use_actions_mask else None
         state = envs.buf_state if self.use_global_state else None


### PR DESCRIPTION
在多智能体强化学习里，test的mean_scores实际上只有真实值的**一半**。

```
            test_info = {
                "Test-Results/Episode-Rewards/Mean-Score": np.mean(scores),
                "Test-Results/Episode-Rewards/Std-Score": np.std(scores),
            }
            self.log_infos(test_info, self.current_step)
```

这是因为在 `on_policy_marl.py` 和 `off_policy_marl.py`里，对`scores`进行了错误的初始化：
```diff
-        episode_count, scores, best_score = 0, [0.0 for _ in range(num_envs)], -np.inf
+        episode_count, scores, best_score = 0, [], -np.inf
```
在这里，`scores`被初始化为一个长度为`num_envs`的数组，然而，在后文中记录scores时使用的是`append`。
```python
(417)          scores.append(episode_score)
```
这导致最后的`scores`长度为初始值的一倍，被mean之后自然就只有一半了。

该pr参考`on_policy.py`里的方法，直接把`scores`的初始值定为空数组，解决了以上问题。

效果：
```
before: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -104.067160996298, -103.8379106471936, -104.6813349922498, -104.14901757240295, -104.5666624456644, -102.56050942341487, -103.5273131231467, -102.78732773661613, -102.85941721250613, -103.53727325300376]
after: [-104.067160996298, -103.8379106471936, -104.6813349922498, -104.14901757240295, -104.5666624456644, -102.56050942341487, -103.5273131231467, -102.78732773661613, -102.85941721250613, -103.53727325300376]
```
---

In multi - agent reinforcement learning, the `mean_scores` in the test are actually only **half** of the real values.

```python
            test_info = {
                "Test-Results/Episode-Rewards/Mean-Score": np.mean(scores),
                "Test-Results/Episode-Rewards/Std-Score": np.std(scores),
            }
            self.log_infos(test_info, self.current_step)
```

This is because in `on_policy_marl.py` and `off_policy_marl.py`, the `scores` were initialized incorrectly:

```diff
-        episode_count, scores, best_score = 0, [0.0 for _ in range(num_envs)], -np.inf
+        episode_count, scores, best_score = 0, [], -np.inf
```

Here, `scores` was initialized as an array with a length of `num_envs`. However, the `append` method was used when recording `scores` later in the code.

```python
(417)          scores.append(episode_score)
```

This results in the final length of `scores` being twice the initial value. Naturally, after taking the mean, it is only half of the real value.

This pull request refers to the method in `on_policy.py` and directly sets the initial value of `scores` to an empty array, thus solving the above - mentioned problem. 


```
before: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -104.067160996298, -103.8379106471936, -104.6813349922498, -104.14901757240295, -104.5666624456644, -102.56050942341487, -103.5273131231467, -102.78732773661613, -102.85941721250613, -103.53727325300376]
after: [-104.067160996298, -103.8379106471936, -104.6813349922498, -104.14901757240295, -104.5666624456644, -102.56050942341487, -103.5273131231467, -102.78732773661613, -102.85941721250613, -103.53727325300376]
```