### PR TITLE
Add critical note for SC2 Editor custom maps

### DIFF
--- a/docs/source/documents/api/environments/multi_agent_env/smac.rst
+++ b/docs/source/documents/api/environments/multi_agent_env/smac.rst
@@ -56,6 +56,11 @@ and extract it to the ``$SC2PATH/Maps$`` directory.
 If you installed ``smac`` via git, simply copy the ``SMAC_Maps`` directory
 from ``smac/env/starcraft2/maps/`` into ``$SC2PATH/Maps`` directory.
 
+.. note::
+
+    When using custom maps created with SC2 Editor, you need to modify the ``version`` in ``t3Terrain.xml`` to 114 using mpqeditor.
+    For more details, please refer to `this issue <https://github.com/google-deepmind/pysc2/issues/326>`_.
+
 Citation
 ''''''''''''''''
 


### PR DESCRIPTION
### Summary
This PR adds an important note in the SMAC installation documentation (Step 3) about handling custom maps created with SC2 Editor.

### Changes
- Added a note explaining that custom maps require modifying the `version` field in `t3Terrain.xml` to 114 using mpqeditor
- Included reference to PySC2 issue #326 for detailed context

### Why this matters
**This is a common issue** that many users face when creating custom SMAC maps. The solution is **not easily discoverable** through typical search methods, often leading users to spend considerable time troubleshooting. Adding this note will help prevent compatibility issues and significantly improve the developer experience.

The note is placed in Step 3 (SMAC Maps section) where users are already learning about map setup, making it contextually appropriate and easy to find when needed.