### PR TITLE
Fix crashes in torch PDQN/MPDQN/SPDQN and Platform env compatibility

### DIFF
--- a/xuance/environment/single_agent_env/platform.py
+++ b/xuance/environment/single_agent_env/platform.py
@@ -1,8 +1,26 @@
-import gymnasium as gym
+import gymnasium
 try:
+    import gym as gym_legacy  # gym-platform is registered against legacy gym.
     import gym_platform
 except ImportError:
     pass
+
+
+def _to_gymnasium_space(space):
+    """Convert a legacy gym space to its gymnasium equivalent (recursively).
+
+    gym-platform exposes legacy gym spaces, but the rest of XuanCe expects
+    gymnasium spaces (e.g. gymnasium.spaces.Tuple asserts its members are
+    gymnasium spaces), so the wrapper converts them at the boundary.
+    """
+    name = type(space).__name__
+    if name == "Box":
+        return gymnasium.spaces.Box(low=space.low, high=space.high, shape=space.shape, dtype=space.dtype)
+    if name == "Discrete":
+        return gymnasium.spaces.Discrete(space.n)
+    if name == "Tuple":
+        return gymnasium.spaces.Tuple(tuple(_to_gymnasium_space(s) for s in space.spaces))
+    raise NotImplementedError(f"Unsupported legacy gym space type: {name}")
 
 
 class PlatformEnv:
@@ -17,13 +35,14 @@ class PlatformEnv:
         super(PlatformEnv, self).__init__()
         self.env_id = config.env_id
         self.render_mode = config.render_mode
-        env = gym.make(self.env_id, max_episode_steps=config.max_episode_steps)
+        env = gym_legacy.make(self.env_id)
         self.env = env.unwrapped
-        self.env.reset(seed=config.env_seed)
+        self.env.seed(config.env_seed)  # legacy gym API: seed() then reset().
+        self.env.reset()
         self.num_envs = 1
 
-        self.observation_space = self.env.observation_space
-        self.action_space = self.env.action_space
+        self.observation_space = _to_gymnasium_space(self.env.observation_space)
+        self.action_space = _to_gymnasium_space(self.env.action_space)
         self.max_episode_steps = config.max_episode_steps
 
     def close(self):

--- a/xuance/torch/agents/policy_gradient/mpdqn_agent.py
+++ b/xuance/torch/agents/policy_gradient/mpdqn_agent.py
@@ -20,7 +20,7 @@ class MPDQN_Agent(PDQN_Agent):
                  config: Namespace,
                  envs: Gym_Env,
                  callback: Optional[BaseCallback] = None):
-        super(MPDQN_Agent, self).__init__(config, envs, observation_space, action_space, callback)
+        super(MPDQN_Agent, self).__init__(config, envs, callback)
 
     def _build_policy(self) -> Module:
         normalize_fn = NormalizeFunctions[self.config.normalize] if hasattr(self.config, "normalize") else None

--- a/xuance/torch/agents/policy_gradient/pdqn_agent.py
+++ b/xuance/torch/agents/policy_gradient/pdqn_agent.py
@@ -25,7 +25,7 @@ class PDQN_Agent(Agent):
                  config: Namespace,
                  envs: Gym_Env,
                  callback: Optional[BaseCallback] = None):
-        super(PDQN_Agent, self).__init__(config, envs, observation_space, action_space, callback)
+        super(PDQN_Agent, self).__init__(config, envs, callback)
 
         self.start_greedy, self.end_greedy = config.start_greedy, config.end_greedy
         self.egreedy = config.start_greedy

--- a/xuance/torch/agents/policy_gradient/spdqn_agent.py
+++ b/xuance/torch/agents/policy_gradient/spdqn_agent.py
@@ -26,7 +26,7 @@ class SPDQN_Agent(PDQN_Agent, Agent):
                  config: Namespace,
                  envs: Gym_Env,
                  callback: Optional[BaseCallback] = None):
-        Agent.__init__(self, config, envs, callback)
+        Agent.__init__(self, config, envs, callback=callback)
         self.start_noise, self.end_noise = config.start_noise, config.end_noise
         self.noise_scale = config.start_noise
         self.delta_noise = (self.start_noise - self.end_noise) / (config.running_steps / self.n_envs)

--- a/xuance/torch/learners/learner.py
+++ b/xuance/torch/learners/learner.py
@@ -126,9 +126,14 @@ class Learner(ABC):
             if type(self.optimizer) is dict:
                 for k, v in self.optimizer.items():
                     v.load_state_dict(checkpoint['optimizer'][k])
+                current_lr = next(iter(self.optimizer.values())).param_groups[0]['lr']
+            elif type(self.optimizer) is list:  # e.g. PDQN-family learners keep [actor, qnet] optimizers.
+                for opt, opt_state in zip(self.optimizer, checkpoint['optimizer']):
+                    opt.load_state_dict(opt_state)
+                current_lr = self.optimizer[0].param_groups[0]['lr']
             else:
                 self.optimizer.load_state_dict(checkpoint['optimizer'])
-            current_lr = self.optimizer.param_groups[0]['lr']
+                current_lr = self.optimizer.param_groups[0]['lr']
             self.learning_rate = current_lr
 
         if 'rng_state' in checkpoint:

--- a/xuance/torch/learners/learner.py
+++ b/xuance/torch/learners/learner.py
@@ -72,6 +72,15 @@ class Learner(ABC):
                     'cuda_rng_state': torch.cuda.get_rng_state_all(),
                 },
                 model_path)
+        elif type(self.optimizer) is list:  # e.g. PDQN-family learners keep [actor, qnet] optimizers.
+            torch.save(
+                {
+                    'policy': self.policy.state_dict(),
+                    'optimizer': [opt.state_dict() for opt in self.optimizer],
+                    'rng_state': torch.get_rng_state(),
+                    'cuda_rng_state': torch.cuda.get_rng_state_all(),
+                },
+                model_path)
         else:
             torch.save(
                 {

--- a/xuance/torch/learners/policy_gradient/mpdqn_learner.py
+++ b/xuance/torch/learners/policy_gradient/mpdqn_learner.py
@@ -17,7 +17,7 @@ class MPDQN_Learner(Learner):
         super(MPDQN_Learner, self).__init__(config, policy, callback)
         conactor_optimizer = torch.optim.Adam(self.policy.conactor.parameters(), self.config.learning_rate)
         qnetwork_optimizer = torch.optim.Adam(self.policy.qnetwork.parameters(), self.config.learning_rate)
-        self.optimizers = [conactor_optimizer, qnetwork_optimizer]
+        self.optimizer = [conactor_optimizer, qnetwork_optimizer]
         conactor_lr_scheduler = torch.optim.lr_scheduler.LinearLR(conactor_optimizer,
                                                                   start_factor=1.0,
                                                                   end_factor=self.end_factor_lr_decay,

--- a/xuance/torch/learners/policy_gradient/pdqn_learner.py
+++ b/xuance/torch/learners/policy_gradient/pdqn_learner.py
@@ -17,7 +17,7 @@ class PDQN_Learner(Learner):
         super(PDQN_Learner, self).__init__(config, policy, callback)
         conactor_optimizer = torch.optim.Adam(self.policy.conactor.parameters(), self.config.learning_rate)
         qnetwork_optimizer = torch.optim.Adam(self.policy.qnetwork.parameters(), self.config.learning_rate)
-        self.optimizers = [conactor_optimizer, qnetwork_optimizer]
+        self.optimizer = [conactor_optimizer, qnetwork_optimizer]
         conactor_lr_scheduler = torch.optim.lr_scheduler.LinearLR(conactor_optimizer,
                                                                   start_factor=1.0,
                                                                   end_factor=self.end_factor_lr_decay,

--- a/xuance/torch/learners/policy_gradient/spdqn_learner.py
+++ b/xuance/torch/learners/policy_gradient/spdqn_learner.py
@@ -16,7 +16,7 @@ class SPDQN_Learner(Learner):
         super(SPDQN_Learner, self).__init__(config, policy, callback)
         conactor_optimizer = torch.optim.Adam(self.policy.conactor.parameters(), self.config.learning_rate)
         qnetwork_optimizer = torch.optim.Adam(self.policy.qnetwork.parameters(), self.config.learning_rate)
-        self.optimizers = [conactor_optimizer, qnetwork_optimizer]
+        self.optimizer = [conactor_optimizer, qnetwork_optimizer]
         conactor_lr_scheduler = torch.optim.lr_scheduler.LinearLR(conactor_optimizer,
                                                                   start_factor=1.0,
                                                                   end_factor=self.end_factor_lr_decay,


### PR DESCRIPTION
## Summary

The torch implementations of the PDQN family (PDQN, MPDQN, SPDQN) currently cannot run: they crash on construction, on the first learner update, and on final model save. The Platform environment wrapper also cannot create `Platform-v0`, because [gym-platform](https://github.com/cycraig/gym-platform) registers against legacy gym while the wrapper uses gymnasium. This PR fixes all of these so the PDQN-family configs (`configs/{pdqn,mpdqn,spdqn}/Platform.yaml`) work end-to-end.

## Bugs fixed

**Commit 1 — torch PDQN-family crashes**

| File | Bug | Symptom |
|---|---|---|
| `torch/learners/policy_gradient/{pdqn,mpdqn,spdqn}_learner.py` | stores `self.optimizers = [...]` but `update()` indexes `self.optimizer[0/1]` (base class leaves it `None`) | `TypeError` on first update |
| `torch/agents/policy_gradient/{pdqn,mpdqn}_agent.py` | passes undefined names `observation_space`, `action_space` to `super().__init__()` | `NameError` on construction |
| `torch/agents/policy_gradient/spdqn_agent.py` | `callback` passed positionally lands in the `observation_space` parameter of `Agent.__init__` | callback silently dropped |
| `torch/learners/learner.py` `save_model()` | no handling for a list of optimizers | `AttributeError: 'list' object has no attribute 'state_dict'` after training |

**Commit 2 — Platform env wrapper**

`gymnasium.make('Platform-v0')` fails because gym-platform registers with legacy gym, and its `reset()` takes no `seed` kwarg. The wrapper now creates the env via legacy gym, seeds with `env.seed()`, and converts the exposed observation/action spaces to gymnasium equivalents so downstream code (`gymnasium.spaces.Tuple` validation in the PDQN agents and the DRL runner) keeps working.

## Verification

With these fixes, MPDQN and PDQN train successfully on Platform-v0 (torch backend, CPU, default `Platform.yaml` configs, 30k steps, 3 seeds each):

| Algorithm | Final return (mean ± std over last 20% of steps) |
|---|---|
| MPDQN | 0.774 ± 0.006 |
| PDQN | 0.766 ± 0.029 |

MPDQN reaches ~0.78 return in ~5k steps vs ~11k for PDQN, and has ~5x lower seed variance — consistent with the MP-DQN paper (Bester et al. 2019, arXiv:1905.04388, Fig. 4a).

Repro: `gym-platform` installed from source (its PyPI-era setup.py omits the `envs` subpackage), then `runner = get_runner(algo='mpdqn', env='Platform', env_id='Platform-v0'); runner.run(mode='train')`.