### PR TITLE
fix(mindspore): run_episodes() call sites pass n_episodes twice, breaking all RNN training

### DIFF
--- a/xuance/mindspore/agents/core/off_policy_marl.py
+++ b/xuance/mindspore/agents/core/off_policy_marl.py
@@ -341,7 +341,7 @@ class OffPolicyMARLAgents(MARLAgents):
                 step_start, step_last = deepcopy(self.current_step), deepcopy(self.current_step)
                 train_steps_all = train_steps * self.n_envs
                 while step_last - step_start < train_steps_all:
-                    self.run_episodes(None, n_episodes=self.n_envs, test_mode=False)
+                    self.run_episodes(n_episodes=self.n_envs, test_mode=False, close_envs=False)
                     if self.current_step >= self.start_training:
                         update_info = self.train_epochs(n_epochs=self.n_epochs)
                         self.log_infos(update_info, self.current_step)

--- a/xuance/mindspore/agents/core/on_policy_marl.py
+++ b/xuance/mindspore/agents/core/on_policy_marl.py
@@ -393,7 +393,7 @@ class OnPolicyMARLAgents(MARLAgents):
                 step_start, step_last = deepcopy(self.current_step), deepcopy(self.current_step)
                 n_steps_all = train_steps * self.n_envs
                 while step_last - step_start < n_steps_all:
-                    self.run_episodes(None, n_episodes=self.n_envs, test_mode=False)
+                    self.run_episodes(n_episodes=self.n_envs, test_mode=False, close_envs=False)
                     update_info = self.train_epochs(n_epochs=self.n_epochs)
                     self.log_infos(update_info, self.current_step)
                     train_info.update(update_info)

--- a/xuance/mindspore/agents/multi_agent_rl/coma_agents.py
+++ b/xuance/mindspore/agents/multi_agent_rl/coma_agents.py
@@ -344,7 +344,7 @@ class COMA_Agents(OnPolicyMARLAgents):
                 step_start, step_last = deepcopy(self.current_step), deepcopy(self.current_step)
                 n_steps_all = train_steps * self.n_envs
                 while step_last - step_start < n_steps_all:
-                    self.run_episodes(None, n_episodes=self.n_envs, test_mode=False)
+                    self.run_episodes(n_episodes=self.n_envs, test_mode=False, close_envs=False)
                     update_info = self.train_epochs(n_epochs=self.n_epochs)
                     self.log_infos(update_info, self.current_step)
                     train_info.update(update_info)

--- a/xuance/mindspore/agents/multi_agent_rl/mfac_agents.py
+++ b/xuance/mindspore/agents/multi_agent_rl/mfac_agents.py
@@ -311,7 +311,7 @@ class MFAC_Agents(OnPolicyMARLAgents):
                 step_start, step_last = deepcopy(self.current_step), deepcopy(self.current_step)
                 n_steps_all = train_steps * self.n_envs
                 while step_last - step_start < n_steps_all:
-                    self.run_episodes(None, n_episodes=self.n_envs, test_mode=False)
+                    self.run_episodes(n_episodes=self.n_envs, test_mode=False, close_envs=False)
                     update_info = self.train_epochs(n_epochs=self.n_epochs)
                     self.log_infos(update_info, self.current_step)
                     train_info.update(update_info)

--- a/xuance/mindspore/agents/multi_agent_rl/mfq_agents.py
+++ b/xuance/mindspore/agents/multi_agent_rl/mfq_agents.py
@@ -205,7 +205,7 @@ class MFQ_Agents(OffPolicyMARLAgents):
                 step_start, step_last = deepcopy(self.current_step), deepcopy(self.current_step)
                 n_steps_all = train_steps * self.n_envs
                 while step_last - step_start < n_steps_all:
-                    self.run_episodes(None, n_episodes=self.n_envs, test_mode=False)
+                    self.run_episodes(n_episodes=self.n_envs, test_mode=False, close_envs=False)
                     if self.current_step >= self.start_training:
                         update_info = self.train_epochs(n_epochs=self.n_epochs)
                         self.log_infos(update_info, self.current_step)


### PR DESCRIPTION
## Problem

All five `use_rnn` training loops in the **MindSpore** backend call `run_episodes` like this:

```python
self.run_episodes(None, n_episodes=self.n_envs, test_mode=False)
```

but the method is declared as

```python
def run_episodes(self,
                 n_episodes: int = 1,
                 run_envs: Optional[DummyVecMultiAgentEnv | SubprocVecMultiAgentEnv] = None,
                 test_mode: bool = False,
                 close_envs: bool = True) -> list:
```

The bare `None` was clearly meant for `run_envs`, but `run_envs` is the *second*
parameter — so `None` binds to `n_episodes`, which is then supplied a second time
by keyword:

```
TypeError: run_episodes() got multiple values for argument 'n_episodes'
```

This fires on the very first iteration, so **MindSpore RNN training (`use_rnn: True`)
cannot start at all** for off-policy MARL, on-policy MARL, COMA, MFAC and MFQ.

## Why this is the right fix: the Torch and TensorFlow twins

`xuance/torch/agents/**` and `xuance/tensorflow/agents/**` carry the same five loops
against an identical signature, and **all ten of them already call it correctly**:

| backend | call site | call |
|---|---|---|
| torch | `agents/core/off_policy_marl.py:340` | `run_episodes(n_episodes=self.n_envs, test_mode=False, close_envs=False)` |
| torch | `agents/core/on_policy_marl.py:389` | same |
| torch | `agents/multi_agent_rl/{coma,mfac,mfq}_agents.py` | same |
| tensorflow | `agents/core/off_policy_marl.py:338` | same |
| tensorflow | `agents/core/on_policy_marl.py:386` | same |
| tensorflow | `agents/multi_agent_rl/{coma,mfac,mfq}_agents.py` | same |
| **mindspore** | **`agents/core/off_policy_marl.py:344`** | **`run_episodes(None, n_episodes=..., test_mode=False)`** |
| **mindspore** | **`agents/core/on_policy_marl.py:396`** | **broken** |
| **mindspore** | **`agents/multi_agent_rl/{coma,mfac,mfq}_agents.py`** | **broken** |

10 correct vs. 5 broken, split cleanly along the backend boundary. This patch makes the
MindSpore call sites character-for-character identical to their Torch/TensorFlow twins —
including `close_envs=False`, which keeps the training envs open across loop iterations
(the MindSpore `run_episodes` body has the same `if close_envs: envs.close()` block at
`off_policy_marl.py:572` that Torch has at `:569`).

## Verification

MindSpore is not installable on this machine, so the two functions' signatures were
rebuilt from the real source with `ast` and the call-site arguments replayed through
`inspect.Signature.bind`, with the Torch/TensorFlow siblings as a control group:

```
mindspore OffPolicyMARLAgents.run_episodes (self, n_episodes='1', run_envs='None', test_mode='False', close_envs='True')
torch     OffPolicyMARLAgents.run_episodes (self, n_episodes='1', run_envs='None', test_mode='False', close_envs='True')

[PASS] mindspore (BUG)  self.run_episodes(None, n_episodes=self.n_envs, test_mode=False)
         bind -> TypeError: multiple values for argument 'n_episodes'
[PASS] mindspore on-policy same call
         bind -> TypeError: multiple values for argument 'n_episodes'
[PASS] torch      (OK) self.run_episodes(n_episodes=..., test_mode=False, close_envs=False)
         bind -> OK
[PASS] tensorflow (OK) same call
         bind -> OK
[PASS] mindspore AFTER PATCH (torch-identical call)
         bind -> OK
[PASS] mindspore on-policy AFTER PATCH
         bind -> OK
```

## Scope

Five one-line changes, MindSpore backend only. No signature, behaviour or public API change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
